### PR TITLE
Fix table styling in surv analysis and drug tables

### DIFF
--- a/risteys_elixir/assets/js/AssocTable.vue
+++ b/risteys_elixir/assets/js/AssocTable.vue
@@ -1,6 +1,6 @@
 <template>
 	<div role="table" class="assoc-scrolling">
-		<div role="rowgroup" id="grid-assoc-header">
+		<div role="rowgroup">
 			<div role="row" class="grid-assoc-header-top">
 				<div role="columnheader">
 					<p>Endpoint</p>
@@ -93,7 +93,7 @@
 				v-bind:class="bg_even(idx) + ' grid-assoc-body'"
 			>
 				<!-- ENDPOINT NAME -->
-				<div role="cell"> <!--v-bind:class="bg_even(idx)" ?? -->
+				<div role="cell">
 					<img src="/images/explag.svg" v-on:click="toggle_fold(pheno.name)" alt="expand data" class="cursor-pointer mini-button">
 					<a :href="'/phenocode/' + pheno.name" :title="pheno.name">{{ pheno.longname }}</a>
 				</div>
@@ -460,10 +460,7 @@ export default {
 }
 
 /* Grid table layout */
-#grid-assoc-header {
-	display: grid;
-	grid-template-columns: 1fr;
-
+[role="rowgroup"]:nth-child(1) {
 	position: sticky;
 	top: 0;
 	background-color: #fafafa;

--- a/risteys_elixir/assets/js/AssocTable.vue
+++ b/risteys_elixir/assets/js/AssocTable.vue
@@ -1,248 +1,269 @@
 <template>
-	<div class="scrolling">
-		<table>
-			<col>
-			<colgroup span="4"></colgroup>
-			<colgroup span="4"></colgroup>
-			<thead>
-				<tr>
-					<th rowspan="2">
-						<div class="border-t border-b h-full pl-2 pt-4">  <!-- div hack to have the borders stay in place on scroll -->
-							Endpoint<br>
-							<input
+	<div role="table" class="assoc-scrolling">
+		<div role="rowgroup" id="grid-assoc-header">
+			<div role="row" class="grid-assoc-header-top">
+				<div role="columnheader">
+					<p>Endpoint</p>
+				</div>
+
+				<div role="columnheader" aria-colspan="4">
+					<p>Before {{ phenocode }}</p>
+				</div>
+
+				<div role="columnheader" aria-colspan="4">
+					<p>After {{ phenocode }}</p>
+				</div>
+			</div>
+
+			<div role="row" class="grid-assoc-header-bottom">
+				<div role="columnheader">
+					<p>
+						<input
 								type="text"
 								placeholder="filter by name"
 								v-on:keyup.stop="refresh_table()"
 								v-model="pheno_filter"
 								class="mt-2">
-						</div>
-					</th>
-					<th colspan="4" scope="colgroup">
-						<div class="border-t h-full pt-2">Before {{ phenocode }}</div>
-					</th>
-					<th colspan="4" scope="colgroup">
-						<div class="border-t h-full pt-2">After {{ phenocode }}</div>
-					</th>
-				</tr>
-				<tr>
-					<th scope="col">
-						<div class="border-b h-full">
-							HR [95%&nbsp;CI] <br>
-							<input type="radio" id="hr_before_asc" value="hr_before_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="hr_before_asc" class="radio-left">▲</label><input type="radio" id="hr_before_desc" value="hr_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="hr_before_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							p <br>
-							<input type="radio" id="pvalue_before_asc" value="pvalue_before_asc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_before_asc" class="radio-left">▲</label><input type="radio" id="pvalue_before_desc" value="pvalue_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_before_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							<abbr data-title="Number of overlapping individuals">N</abbr> <br>
-							<input type="radio" id="nindivs_before_asc" value="nindivs_before_asc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_before_asc" class="radio-left">▲</label><input type="radio" id="nindivs_before_desc" value="nindivs_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_before_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							<HelpCompBox /> <br>
-							<input type="radio" id="compbox_before_asc" value="compbox_before_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="compbox_before_asc" class="radio-left">▲</label><input type="radio" id="compbox_before_desc" value="compbox_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="compbox_before_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							HR [95%&nbsp;CI] <br>
-							<input type="radio" id="hr_after_asc" value="hr_after_asc" v-model="sorter" v-on:change="refresh_table()"><label for="hr_after_asc" class="radio-left">▲</label><input type="radio" id="hr_after_desc" value="hr_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="hr_after_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							p <br>
-							<input type="radio" id="pvalue_after_asc" value="pvalue_after_asc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_after_asc" class="radio-left">▲</label><input type="radio" id="pvalue_after_desc" value="pvalue_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_after_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							<abbr data-title="Number of overlapping individuals">N</abbr> <br>
-							<input type="radio" id="nindivs_after_asc" value="nindivs_after_asc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_after_asc" class="radio-left">▲</label><input type="radio" id="nindivs_after_desc" value="nindivs_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_after_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th scope="col">
-						<div class="border-b h-full">
-							<HelpCompBox /> <br>
-							<input type="radio" id="compbox_after_asc" value="compbox_after_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="compbox_after_asc" class="radio-left">▲</label><input type="radio" id="compbox_after_desc" value="compbox_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="compbox_after_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<template v-for="(pheno, idx) in assoc_table">
-					<!-- LAG: no lag -->
-					<tr v-bind:class="bg_even(idx)">
-						<!-- ENDPOINT NAME -->
-						<th v-bind:class="bg_even(idx)">
-							<img src="/images/explag.svg" v-on:click="toggle_fold(pheno.name)" alt="expand data" class="cursor-pointer mini-button">
-							<a :href="'/phenocode/' + pheno.name" :title="pheno.name">{{ pheno.longname }}</a>
-						</th>
+						</p>
+				</div>
 
-						<!-- (before) HR -->
-						<td v-if="pheno.all.before.hr === null">-</td>
-						<td v-else-if="pheno.all.before.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.all.before.hr_str }}&nbsp;[{{ pheno.all.before.ci_min }},&nbsp;{{ pheno.all.before.ci_max }}]</td>
+				<div role="columnheader">
+					<p>HR [95%&nbsp;CI]</p>
+					<p>
+						<input type="radio" id="hr_before_asc" value="hr_before_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="hr_before_asc" class="radio-left">▲</label><input type="radio" id="hr_before_desc" value="hr_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="hr_before_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (before) P-VALUE -->
-						<td v-if="pheno.all.before.pvalue === null">-</td>
-						<td v-else>{{ pheno.all.before.pvalue_str }}</td>
+				<div role="columnheader">
+					<p>p</p>
+					<p>
+						<input type="radio" id="pvalue_before_asc" value="pvalue_before_asc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_before_asc" class="radio-left">▲</label><input type="radio" id="pvalue_before_desc" value="pvalue_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_before_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (before) N-INDIVS -->
-						<td v-if="pheno.all.before.nindivs === null">-</td>
-						<td v-else>{{ pheno.all.before.nindivs }}</td>
+				<div role="columnheader">
+					<p><abbr data-title="Number of overlapping individuals">N</abbr></p>
+					<p>
+						<input type="radio" id="nindivs_before_asc" value="nindivs_before_asc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_before_asc" class="radio-left">▲</label><input type="radio" id="nindivs_before_desc" value="nindivs_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_before_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (before) COMPBOX -->
-						<td v-if="pheno.all.before.hr_binned === null">-</td>
- 						<td	v-else
- 							v-html="compBox(pheno.all.before.hr_binned)"
- 							v-bind:title="textPercentile(Math.trunc(pheno.all.before.hr_binned * 100)) + ' percentile'">
-						</td>
+				<div role="columnheader">
+					<p><HelpCompBox /></p>
+					<p>
+						<input type="radio" id="compbox_before_asc" value="compbox_before_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="compbox_before_asc" class="radio-left">▲</label><input type="radio" id="compbox_before_desc" value="compbox_before_desc" v-model="sorter" v-on:change="refresh_table()"><label for="compbox_before_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (after) HR -->
-						<td v-if="pheno.all.after.hr === null">-</td>
-						<td v-else-if="pheno.all.after.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.all.after.hr_str }}&nbsp;[{{ pheno.all.after.ci_min }},&nbsp;{{ pheno.all.after.ci_max }}]</td>
+				<div role="columnheader">
+					<p>HR [95%&nbsp;CI]</p>
+					<p>
+						<input type="radio" id="hr_after_asc" value="hr_after_asc" v-model="sorter" v-on:change="refresh_table()"><label for="hr_after_asc" class="radio-left">▲</label><input type="radio" id="hr_after_desc" value="hr_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="hr_after_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (after) P-VALUE -->
-						<td v-if="pheno.all.after.pvalue === null">-</td>
-						<td v-else>{{ pheno.all.after.pvalue_str }}</td>
+				<div role="columnheader">
+					<p>p</p>
+					<p>
+						<input type="radio" id="pvalue_after_asc" value="pvalue_after_asc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_after_asc" class="radio-left">▲</label><input type="radio" id="pvalue_after_desc" value="pvalue_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_after_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (after) N-INDIVS -->
-						<td v-if="pheno.all.after.nindivs === null">-</td>
-						<td v-else>{{ pheno.all.after.nindivs }}</td>
+				<div role="columnheader">
+					<p><abbr data-title="Number of overlapping individuals">N</abbr></p>
+					<p>
+						<input type="radio" id="nindivs_after_asc" value="nindivs_after_asc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_after_asc" class="radio-left">▲</label><input type="radio" id="nindivs_after_desc" value="nindivs_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_after_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-						<!-- (after) COMPBOX -->
-						<td v-if="pheno.all.after.hr_binned === null">-</td>
-						<td v-else
-							v-html="compBox(pheno.all.after.hr_binned)"
-							v-bind:title="textPercentile(Math.trunc(pheno.all.after.hr_binned * 100)) + ' percentile'"
-							>
-						</td>
-					</tr>
+				<div role="columnheader">
+					<p><HelpCompBox /></p>
+					<p>
+						<input type="radio" id="compbox_after_asc" value="compbox_after_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="compbox_after_asc" class="radio-left">▲</label><input type="radio" id="compbox_after_desc" value="compbox_after_desc" v-model="sorter" v-on:change="refresh_table()"><label for="compbox_after_desc" class="radio-right">▼</label>
+					</p>
+				</div>
 
-					<!-- LAG: 1 YEAR -->
-					<tr v-bind:class="bg_even(idx)" v-if="unfolded.has(pheno.name)">
-						<!-- LAG -->
-						<th v-bind:class="bg_even(idx)" class="text-right pr-5">&lt;1 year follow-up</th>
+			</div>
+		</div>
 
-						<!-- (before) HR -->
-						<td v-if="pheno.lagged_1y.before.hr === null">-</td>
-						<td v-else-if="pheno.lagged_1y.before.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.lagged_1y.before.hr_str }}&nbsp;[{{ pheno.lagged_1y.before.ci_min }},&nbsp;{{ pheno.lagged_1y.before.ci_max }}]</td>
+		<div v-for="(pheno, idx) in assoc_table" role="rowgroup">
+			<!-- LAG: no lag -->
+			<div
+				role="row"
+				v-bind:class="bg_even(idx) + ' grid-assoc-body'"
+			>
+				<!-- ENDPOINT NAME -->
+				<div role="cell"> <!--v-bind:class="bg_even(idx)" ?? -->
+					<img src="/images/explag.svg" v-on:click="toggle_fold(pheno.name)" alt="expand data" class="cursor-pointer mini-button">
+					<a :href="'/phenocode/' + pheno.name" :title="pheno.name">{{ pheno.longname }}</a>
+				</div>
 
-						<!-- (before) P-VALUE -->
-						<td v-if="pheno.lagged_1y.before.pvalue === null">-</td>
-						<td v-else>{{ pheno.lagged_1y.before.pvalue_str }}</td>
+				<!-- (before) HR -->
+				<div role="cell" v-if="pheno.all.before.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.all.before.hr >100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.all.before.hr_str }} [{{ pheno.all.before.ci_min }},&nbsp;{{ pheno.all.before.ci_max }}]</div>
 
-						<!-- (before) N-INDIVS -->
-						<td v-if="pheno.lagged_1y.before.nindivs === null">-</td>
-						<td v-else>{{ pheno.lagged_1y.before.nindivs }}</td>
+				<!-- (before) P-VALUE -->
+				<div role="cell" v-if="pheno.all.before.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.all.before.pvalue_str }}</div>
 
-						<!-- (before) COMPBOX -->
-						<td>-</td>
+				<!-- (before) N-INDIVS -->
+				<div role="cell" v-if="pheno.all.before.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.all.before.nindivs }}</div>
 
-						<!-- (after) HR -->
-						<td v-if="pheno.lagged_1y.after.hr === null">-</td>
-						<td v-else-if="pheno.lagged_1y.after.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.lagged_1y.after.hr_str }}&nbsp;[{{ pheno.lagged_1y.after.ci_min }},&nbsp;{{ pheno.lagged_1y.after.ci_max }}]</td>
+				<!-- (before) COMPBOX -->
+				<div role="cell" v-if="pheno.all.before.hr_binned === null">-</div>
+ 				<div role="cell" v-else
+ 					v-html="compBox(pheno.all.before.hr_binned)"
+ 					v-bind:title="textPercentile(Math.trunc(pheno.all.before.hr_binned * 100)) + ' percentile'">
+				</div>
 
-						<!-- (after) P-VALUE -->
-						<td v-if="pheno.lagged_1y.after.pvalue === null">-</td>
-						<td v-else>{{ pheno.lagged_1y.after.pvalue_str }}</td>
+				<!-- (after) HR -->
+				<div role="cell" v-if="pheno.all.after.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.all.after.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.all.after.hr_str }} [{{ pheno.all.after.ci_min }},&nbsp;{{ pheno.all.after.ci_max }}]</div>
 
-						<!-- (after) N-INDIVS -->
-						<td v-if="pheno.lagged_1y.after.nindivs === null">-</td>
-						<td v-else>{{ pheno.lagged_1y.after.nindivs }}</td>
+				<!-- (after) P-VALUE -->
+				<div role="cell" v-if="pheno.all.after.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.all.after.pvalue_str }}</div>
 
-						<!-- (after) COMPBOX -->
-						<td>-</td>
-					</tr>
+				<!-- (after) N-INDIVS -->
+				<div role="cell" v-if="pheno.all.after.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.all.after.nindivs }}</div>
 
-					<!-- LAG: 5 YEARS -->
-					<tr v-bind:class="bg_even(idx)" v-if="unfolded.has(pheno.name)">
-						<!-- LAG -->
-						<th v-bind:class="bg_even(idx)" class="text-right pr-5">&lt;1-5 year follow-up</th>
+				<!-- (after) COMPBOX -->
+				<div role="cell" v-if="pheno.all.after.hr_binned === null">-</div>
+				<div role="cell" v-else
+					v-html="compBox(pheno.all.after.hr_binned)"
+					v-bind:title="textPercentile(Math.trunc(pheno.all.after.hr_binned * 100)) + ' percentile'"
+					>
+				</div>
+			</div>
 
-						<!-- (before) HR -->
-						<td v-if="pheno.lagged_5y.before.hr === null">-</td>
-						<td v-else-if="pheno.lagged_5y.before.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.lagged_5y.before.hr_str }}&nbsp;[{{ pheno.lagged_5y.before.ci_min }},&nbsp;{{ pheno.lagged_5y.before.ci_max }}]</td>
+			<!-- LAG: 1 YEAR -->
+			<div
+				role="row"
+				v-bind:class="bg_even(idx) + ' grid-assoc-body'" v-if="unfolded.has(pheno.name)"
+			>
 
-						<!-- (before) P-VALUE -->
-						<td v-if="pheno.lagged_5y.before.pvalue === null">-</td>
-						<td v-else>{{ pheno.lagged_5y.before.pvalue_str }}</td>
+				<!-- LAG -->
+				<div role="cell" v-bind:class="bg_even(idx)">&lt;1 year follow-up</div>
 
-						<!-- (before) N-INDIVS -->
-						<td v-if="pheno.lagged_5y.before.nindivs === null">-</td>
-						<td v-else>{{ pheno.lagged_5y.before.nindivs }}</td>
+				<!-- (before) HR -->
+				<div role="cell" v-if="pheno.lagged_1y.before.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.lagged_1y.before.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.lagged_1y.before.hr_str }} [{{ pheno.lagged_1y.before.ci_min }},&nbsp;{{ pheno.lagged_1y.before.ci_max }}]</div>
 
-						<!-- (before) COMPBOX -->
-						<td>-</td>
+				<!-- (before) P-VALUE -->
+				<div role="cell" v-if="pheno.lagged_1y.before.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_1y.before.pvalue_str }}</div>
 
-						<!-- (after) HR -->
-						<td v-if="pheno.lagged_5y.after.hr === null">-</td>
-						<td v-else-if="pheno.lagged_5y.after.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.lagged_5y.after.hr_str }}&nbsp;[{{ pheno.lagged_5y.after.ci_min }},&nbsp;{{ pheno.lagged_5y.after.ci_max }}]</td>
+				<!-- (before) N-INDIVS -->
+				<div role="cell" v-if="pheno.lagged_1y.before.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_1y.before.nindivs }}</div>
 
-						<!-- (after) P-VALUE -->
-						<td v-if="pheno.lagged_5y.after.pvalue === null">-</td>
-						<td v-else>{{ pheno.lagged_5y.after.pvalue_str }}</td>
+				<!-- (before) COMPBOX -->
+				<div role="cell">-</div>
 
-						<!-- (after) N-INDIVS -->
-						<td v-if="pheno.lagged_5y.after.nindivs === null">-</td>
-						<td v-else>{{ pheno.lagged_5y.after.nindivs }}</td>
+				<!-- (after) HR -->
+				<div role="cell" v-if="pheno.lagged_1y.after.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.lagged_1y.after.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.lagged_1y.after.hr_str }} [{{ pheno.lagged_1y.after.ci_min }},&nbsp;{{ pheno.lagged_1y.after.ci_max }}]</div>
 
-						<!-- (after) COMPBOX -->
-						<td>-</td>
-					</tr>
+				<!-- (after) P-VALUE -->
+				<div role="cell" v-if="pheno.lagged_1y.after.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_1y.after.pvalue_str }}</div>
 
-					<!-- LAG: 15 YEARS -->
-					<tr v-bind:class="bg_even(idx)" v-if="unfolded.has(pheno.name)">
-						<!-- LAG -->
-						<th v-bind:class="bg_even(idx)" class="text-right pr-5">&lt;5-15 year follow-up</th>
+				<!-- (after) N-INDIVS -->
+				<div role="cell" v-if="pheno.lagged_1y.after.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_1y.after.nindivs }}</div>
 
-						<!-- (before) HR -->
-						<td v-if="pheno.lagged_15y.before.hr === null">-</td>
-						<td v-else-if="pheno.lagged_15y.before.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.lagged_15y.before.hr_str }}&nbsp;[{{ pheno.lagged_15y.before.ci_min }},&nbsp;{{ pheno.lagged_15y.before.ci_max }}]</td>
+				<!-- (after) COMPBOX -->
+				<div role="cell">-</div>
+			</div>
 
-						<!-- (before) P-VALUE -->
-						<td v-if="pheno.lagged_15y.before.pvalue === null">-</td>
-						<td v-else>{{ pheno.lagged_15y.before.pvalue_str }}</td>
+			<!-- LAG: 5 YEARS -->
+			<div
+				role="row"
+				v-bind:class="bg_even(idx) + ' grid-assoc-body'" v-if="unfolded.has(pheno.name)"
+			>
+				<!-- LAG -->
+				<div role="cell" v-bind:class="bg_even(idx)">&lt;1-5 year follow-up</div>
 
-						<!-- (before) N-INDIVS -->
-						<td v-if="pheno.lagged_15y.before.nindivs === null">-</td>
-						<td v-else>{{ pheno.lagged_15y.before.nindivs }}</td>
+				<!-- (before) HR -->
+				<div role="cell" v-if="pheno.lagged_5y.before.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.lagged_5y.before.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.lagged_5y.before.hr_str }} [{{ pheno.lagged_5y.before.ci_min }},&nbsp;{{ pheno.lagged_5y.before.ci_max }}]</div>
 
-						<!-- (before) COMPBOX -->
-						<td>-</td>
+				<!-- (before) P-VALUE -->
+				<div role="cell" v-if="pheno.lagged_5y.before.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_5y.before.pvalue_str }}</div>
 
-						<!-- (after) HR -->
-						<td v-if="pheno.lagged_15y.after.hr === null">-</td>
-						<td v-else-if="pheno.lagged_15y.after.hr > 100">&gt;&nbsp;100</td>
-						<td v-else>{{ pheno.lagged_15y.after.hr_str }}&nbsp;[{{ pheno.lagged_15y.after.ci_min }},&nbsp;{{ pheno.lagged_15y.after.ci_max }}]</td>
+				<!-- (before) N-INDIVS -->
+				<div role="cell" v-if="pheno.lagged_5y.before.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_5y.before.nindivs }}</div>
 
-						<!-- (after) P-VALUE -->
-						<td v-if="pheno.lagged_15y.after.pvalue === null">-</td>
-						<td v-else>{{ pheno.lagged_15y.after.pvalue_str }}</td>
+				<!-- (before) COMPBOX -->
+				<div role="cell">-</div>
 
-						<!-- (after) N-INDIVS -->
-						<td v-if="pheno.lagged_15y.after.nindivs === null">-</td>
-						<td v-else>{{ pheno.lagged_15y.after.nindivs }}</td>
+				<!-- (after) HR -->
+				<div role="cell" v-if="pheno.lagged_5y.after.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.lagged_5y.after.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.lagged_5y.after.hr_str }} [{{ pheno.lagged_5y.after.ci_min }},&nbsp;{{ pheno.lagged_5y.after.ci_max }}]</div>
 
-						<!-- (after) COMPBOX -->
-						<td>-</td>
-					</tr>
-				</template>
-			</tbody>
-		</table>
+				<!-- (after) P-VALUE -->
+				<div role="cell" v-if="pheno.lagged_5y.after.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_5y.after.pvalue_str }}</div>
+
+				<!-- (after) N-INDIVS -->
+				<div role="cell" v-if="pheno.lagged_5y.after.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_5y.after.nindivs }}</div>
+
+				<!-- (after) COMPBOX -->
+				<div role="cell">-</div>
+			</div>
+
+			<!-- LAG: 15 YEARS -->
+			<div
+				role="row"
+				v-bind:class="bg_even(idx) + ' grid-assoc-body'" v-if="unfolded.has(pheno.name)"
+			>
+				<!-- LAG -->
+				<div role="cell" v-bind:class="bg_even(idx)">&lt;5-15 year follow-up</div>
+
+				<!-- (before) HR -->
+				<div role="cell" v-if="pheno.lagged_15y.before.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.lagged_15y.before.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.lagged_15y.before.hr_str }} [{{ pheno.lagged_15y.before.ci_min }},&nbsp;{{ pheno.lagged_15y.before.ci_max }}]</div>
+
+				<!-- (before) P-VALUE -->
+				<div role="cell" v-if="pheno.lagged_15y.before.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_15y.before.pvalue_str }}</div>
+
+				<!-- (before) N-INDIVS -->
+				<div role="cell" v-if="pheno.lagged_15y.before.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_15y.before.nindivs }}</div>
+
+				<!-- (before) COMPBOX -->
+				<div role="cell">-</div>
+
+				<!-- (after) HR -->
+				<div role="cell" v-if="pheno.lagged_15y.after.hr === null">-</div>
+				<div role="cell" v-else-if="pheno.lagged_15y.after.hr > 100">&gt;&nbsp;100</div>
+				<div role="cell" v-else>{{ pheno.lagged_15y.after.hr_str }} [{{ pheno.lagged_15y.after.ci_min }},&nbsp;{{ pheno.lagged_15y.after.ci_max }}]</div>
+
+				<!-- (after) P-VALUE -->
+				<div role="cell" v-if="pheno.lagged_15y.after.pvalue === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_15y.after.pvalue_str }}</div>
+
+				<!-- (after) N-INDIVS -->
+				<div role="cell" v-if="pheno.lagged_15y.after.nindivs === null">-</div>
+				<div role="cell" v-else>{{ pheno.lagged_15y.after.nindivs }}</div>
+
+				<!-- (after) COMPBOX -->
+				<div role="cell">-</div>
+			</div>
+		</div>
 	</div>
 </template>
 
@@ -420,73 +441,63 @@ export default {
 </script>
 
 <style type="text/css" scoped>
-div.scrolling {
-	max-width: 100%;
+
+.assoc-scrolling {
 	max-height: 500px;
-	overflow: scroll;
+	overflow-y: scroll;
 	position: relative;
 
-	font-size: 0.6rem;
-}
-
-.scrolling table {
-	position: relative;
-	border-collapse: collapse;
-}
-
-.scrolling th, .scrolling td {
-	@apply px-1;
-}
-
-/* Allow div hack that shows borders on scroll */
-.scrolling thead th, .scrolling thead td {
+	/* If not set, scrolled text will appear above the table header.
+	   We could have used padding-top: 0; only, but it actually looks better
+	   with no padding at all.
+	 */
 	padding: 0;
 }
 
-/* thead gray background */
-.scrolling thead th {
-	@apply bg-grey-lightest;
+/* Reset default display: table; from browsers */
+[role="table"] {
+	display: block;
 }
 
-/* thead: endpoint cell */
-.scrolling thead tr:first-child th:first-child {
-	left: 0;
-	z-index: 1;
-	height: 100px;
-}
+/* Grid table layout */
+#grid-assoc-header {
+	display: grid;
+	grid-template-columns: 1fr;
 
-/* thead: top row */
-.scrolling thead tr:nth-child(1) th {
 	position: sticky;
-
 	top: 0;
-	height: 40px;
+	background-color: #fafafa;
+	border-top-width: 1px;
+	border-bottom-width: 1px;
+	font-weight: bold;
 }
 
-/* thead: bottom row */;
-.scrolling thead tr:nth-child(2) th {
-	position: sticky;
-
-	top: 40px;
-	height: 60px;
-	line-height: 1.5;
+.grid-assoc-header-top {
+	display: grid;
+	grid-template-columns: 6fr 9fr 9fr;
 }
 
-/* tbody: leftmost column */
-.scrolling tbody th {
-  position: -webkit-sticky; /* for Safari */
-  position: sticky;
-  left: 0;
-  font-weight: normal;
+.grid-assoc-header-bottom {
+	display: grid;
+	grid-template-columns: 6fr 3fr 2fr 2fr 2fr 3fr 2fr 2fr 2fr;
+}
+.grid-assoc-body {
+	display: grid;
+	grid-template-columns: 6fr 3fr 2fr 2fr 2fr 3fr 2fr 2fr 2fr;
 }
 
-@media (min-width: 650px) {
-	div.scrolling {
-		font-size: 1rem;
-	}
-
-	.scrolling th, .scrolling td {
-		@apply px-3;
-	}
+/* Place table header widget near the bottom */
+[role="columnheader"] {
+	display: grid;
+	grid-template-columns: 1fr;
 }
+[role="columnheader"] p:last-child {
+	align-self: end;
+	margin-top: 0.25rem;
+}
+/* Hide overflowing endpoint code name */
+[role="cell"]:nth-child(1) {
+	overflow: hidden;
+}
+
 </style>

--- a/risteys_elixir/assets/js/DrugTable.vue
+++ b/risteys_elixir/assets/js/DrugTable.vue
@@ -1,63 +1,61 @@
 <template>
-	<div class="scrolling">
-		<table class="w-full">
-			<thead>
-				<tr>
-					<th>
-						<div class="h-full border-b border-t pl-2 pt-4">  <!-- div hack to have the borders stay in place on scroll -->
-							Name <br>
-							<input
-								type="text"
-								placeholder="filter by drug name or ATC"
-								v-model="drug_filter"
-								v-on:keyup.stop="refresh_table()"
-								>
-						</div>
-					</th>
-					<th>
-						<div class="h-full border-t border-b">
-							<div><HelpDrugScore v-bind:phenocode="this.phenocode" /> Score</div>
-					<input type="radio" id="score_asc" value="score_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="score_asc" class="radio-left">▲</label><input type="radio" id="score_desc" value="score_desc" v-model="sorter" v-on:change="refresh_table()"><label for="score_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th>
-						<div class="h-full border-t border-b">
-							[95% CI]
-						</div>
-					</th>
-					<th>
-						<div class="h-full border-t border-b">
-							p <br>
-				<input type="radio" id="pvalue_asc" value="pvalue_asc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_asc" class="radio-left">▲</label><input type="radio" id="pvalue_desc" value="pvalue_desc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th>
-						<div class="h-full border-t border-b">
-							N <br>
-				<input type="radio" id="nindivs_asc" value="nindivs_asc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_asc" class="radio-left">▲</label><input type="radio" id="nindivs_desc" value="nindivs_desc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-					<th>
-						<div class="h-full border-t border-b">
-							ATC code <br>
-				<input type="radio" id="atc_asc" value="atc_asc" v-model="sorter" v-on:change="refresh_table()"><label for="atc_asc" class="radio-left">▲</label><input type="radio" id="atc_desc" value="atc_desc" v-model="sorter" v-on:change="refresh_table()"><label for="atc_desc" class="radio-right">▼</label>
-						</div>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<template v-for="(drug, idx) in drug_table">
-					<tr v-bind:class="bg_class(idx)">
-						<th v-bind:class="bg_class(idx)">{{ drug.name }}</th>
-						<td>{{ drug.score_str }}</td>
-						<td>[{{ drug.ci_min_str }}, {{ drug.ci_max_str }}]</td>
-						<td>{{ drug.pvalue_str }}</td>
-						<td>{{ drug.n_indivs }}</td>
-						<td><a v-bind:href="drug.atc_link" target="_blank" rel="noopener noreferrer external">{{ drug.atc }}</a></td>
-					</tr>
-				</template>
-			</tbody>
-		</table>
+	<div role="table" class="drug-scrolling">
+		<div role="rowgroup">
+			<div role="row" class="grid-drug-header">
+				<div role="columnheader">
+					<p>Name</p>
+					<p class="end-align">
+						<input
+							type="text"
+							class="filter-input"
+							placeholder="filter by drug name or ATC"
+							v-model="drug_filter"
+							v-on:keyup.stop="refresh_table()"
+						>
+					</p>
+				</div>
+				<div role="columnheader">
+					<p><HelpDrugScore v-bind:phenocode="this.phenocode" /> Score</p>
+					<p class="end-align">
+						<input type="radio" id="score_asc" value="score_asc" v-model="sorter" v-on:change="refresh_table()" checked><label for="score_asc" class="radio-left">▲</label><input type="radio" id="score_desc" value="score_desc" v-model="sorter" v-on:change="refresh_table()"><label for="score_desc" class="radio-right">▼</label>
+					</p>
+				</div>
+				<div role="columnheader">
+					<p>[95% CI]</p>
+				</div>
+				<div role="columnheader">
+					<p>p </p>
+					<p class="end-align">
+						<input type="radio" id="pvalue_asc" value="pvalue_asc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_asc" class="radio-left">▲</label><input type="radio" id="pvalue_desc" value="pvalue_desc" v-model="sorter" v-on:change="refresh_table()"><label for="pvalue_desc" class="radio-right">▼</label>
+					</p>
+				</div>
+				<div role="columnheader">
+					<p>N <p>
+					<p class="end-align">
+						<input type="radio" id="nindivs_asc" value="nindivs_asc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_asc" class="radio-left">▲</label><input type="radio" id="nindivs_desc" value="nindivs_desc" v-model="sorter" v-on:change="refresh_table()"><label for="nindivs_desc" class="radio-right">▼</label>
+					</p>
+				</div>
+				<div role="columnheader">
+					<p>ATC code </p>
+					<p class="end-align">
+						<input type="radio" id="atc_asc" value="atc_asc" v-model="sorter" v-on:change="refresh_table()"><label for="atc_asc" class="radio-left">▲</label><input type="radio" id="atc_desc" value="atc_desc" v-model="sorter" v-on:change="refresh_table()"><label for="atc_desc" class="radio-right">▼</label>
+					</p>
+				</div>
+			</div>
+		</div>
+		<div role="rowgroup">
+			<template v-for="(drug, idx) in drug_table">
+				<div role="row" v-bind:class="bg_class(idx) + ' grid-drug-body'">
+					<div role="cell" v-bind:class="bg_class(idx)">{{ drug.name }}</div>
+					<div role="cell">{{ drug.score_str }}</div>
+					<div role="cell">[{{ drug.ci_min_str }}, {{ drug.ci_max_str }}]</div>
+					<div role="cell">{{ drug.pvalue_str }}</div>
+					<div role="cell">{{ drug.n_indivs }}</div>
+					<div role="cell"><a v-bind:href="drug.atc_link" target="_blank" rel="noopener noreferrer external">{{ drug.atc }}</a></div>
+				</div>
+			</template>
+		</div>
+
 		<template v-if="drug_table.length == 0">
 			<p>No data.</p>
 		</template>
@@ -159,65 +157,59 @@ export default {
 
 
 <style scoped>
-div.scrolling {
+.drug-scrolling {
 	max-width: 100%;
 	max-height: 500px;
 	overflow: scroll;
 	position: relative;
 
-	font-size: 0.8rem;
-}
-
-.scrolling table {
-	position: relative;
-	border-collapse: collapse;
-}
-
-.scrolling th, .scrolling td {
-	@apply px-1;
-}
-
-/* Allow div hack that shows borders on scroll */
-.scrolling thead th, .scrolling thead td {
+	/* If not set, scrolled text will appear above the table header.
+    We could have used padding-top: 0; only, but it actually looks better
+	with no padding at all.*/
 	padding: 0;
 }
 
-/* thead gray background */
-.scrolling thead th {
-	@apply bg-grey-lightest;
+ /* Reset default display: table; from browsers */
+[role="table"] {
+	display: block;
 }
 
-/* thead: drug cell */
-.scrolling thead tr:first-child th:first-child {
-	left: 0;
-	z-index: 1;
-	height: 80px;
-}
-
-/* thead: row */
-.scrolling thead tr th {
+[role="rowgroup"]:nth-child(1) {
 	position: sticky;
-
 	top: 0;
-	line-height: 1.5;
-	height: 80px;
+	background-color: #fafafa;
+	border-top-width: 1px;
+	border-bottom-width: 1px;
+
+	font-weight: bold;
 }
 
-/* tbody: leftmost column */
-.scrolling tbody th {
-  position: -webkit-sticky; /* for Safari */
-  position: sticky;
-  left: 0;
-  font-weight: normal;
+/* Grid table layout */
+.grid-drug-header {
+	display: grid;
+	grid-template-columns: 9fr 2fr 2fr 2fr 2fr 2fr;  /* first column spans 2 body columns */
+}
+.grid-drug-body {
+	display: grid;
+	grid-template-columns: 9fr 2fr 2fr 2fr 2fr 2fr;
 }
 
-@media (min-width: 650px) {
-	div.scrolling {
-		font-size: 1rem;
-	}
+/* Place table header widget near the bottom */
+[role="columnheader"] {
+	display: grid;
+	grid-template-columns: 1fr;
+}
+.end-align {
+	align-self: end;
+	margin-top: 0.25rem;
+}
 
-	.scrolling th, .scrolling td {
-		@apply px-3;
-	}
+/* Hide overflowing endpoint code name */
+[role="cell"]:nth-child(1) {
+	overflow: hidden;
+}
+
+.filter-input {
+	width: 40%;
 }
 </style>


### PR DESCRIPTION
Fix the headers of survival analysis and drug tables: make background
be even and widgets be on the same level with each other (previously
different parts were not inline)

Allow HR results to wrap to make columns be inline

Change column widths to make p-values fit better