### PR TITLE
Add R7 link & change link order in the narrow nav

### DIFF
--- a/risteys_elixir/lib/risteys_web/templates/layout/minimal.html.heex
+++ b/risteys_elixir/lib/risteys_web/templates/layout/minimal.html.heex
@@ -46,10 +46,11 @@
 						<a href="https://airtable.com/shrTzTwby7JhFEqi6" target="_blank" rel="noopener noreferrer external"><b>Contact &amp; Feedback</b></a>
 						<div  id="subnav-narrow">
 							<p>Other FinnGen data releases</p>
-							<p><a href="https://r3.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R3</a></p>
-							<p><a href="https://r4.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R4</a></p>
-							<p><a href="https://r5.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R5</a></p>
+							<p><a href="https://r7.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R7</a></p>
 							<p><a href="https://r6.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R6</a></p>
+							<p><a href="https://r5.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R5</a></p>
+							<p><a href="https://r4.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R4</a></p>
+							<p><a href="https://r3.risteys.finngen.fi" target="_blank" rel="noopener noreferrer external">R3</a></p>
 						</div>
 					</p>
 				</nav>


### PR DESCRIPTION
In a narrow home page navigation menu, links to previous Risteys versions were in opposite order than in other menus and a link to R7 Risteys was missing.