### PR TITLE
Bugfix: make changing missing values to nil's work

### DIFF
--- a/risteys_elixir/import_endpoint_csv.exs
+++ b/risteys_elixir/import_endpoint_csv.exs
@@ -275,7 +275,7 @@ end)
 # Replace NA values with nil
 |> Stream.map(fn row ->
   Enum.reduce(row, %{}, fn {header, value}, acc ->
-    value = if value == ["NA", ""], do: nil, else: value
+    value = if value in ["NA", ""], do: nil, else: value
     Map.put_new(acc, header, value)
   end)
 end)
@@ -307,7 +307,7 @@ end)
 |> Stream.map(fn row ->
   reason =
     cond do
-      row.reason_non_core == "" ->
+      is_nil(row.reason_non_core) ->
         nil
 
       row.reason_non_core =~ "EXALLC priorities" ->


### PR DESCRIPTION
This commit fixes a bug in converting missing values to nil's in the import script of endpoint definitions and makes later code in the script to work with the nil values.